### PR TITLE
Update config.py

### DIFF
--- a/watson_worktime/config.py
+++ b/watson_worktime/config.py
@@ -14,6 +14,7 @@ DEFAULT_CONFIG = {
     "state": "BW",
     "hours-per-day": 8,
     "workdays": ["monday", "tuesday", "wednesday", "thursday", "friday"],
+    "start-date": "2000-01-01",
 }
 
 


### PR DESCRIPTION
Added requested config option "start-date" which allows users to modify the default start-date of their overtime calculations.